### PR TITLE
GW exact camera defaults + runtime projection reset

### DIFF
--- a/SourceFiles/Camera.h
+++ b/SourceFiles/Camera.h
@@ -82,7 +82,7 @@ private:
     void UpdateProjectionMatrix();
 
     // Set for perspective projection
-    float m_fov = 70 * XM_PI / 180;
+    float m_fov = 50 * XM_PI / 180;
     float m_aspectRatio = 1;
 
     // Set for orthographic projection
@@ -91,7 +91,7 @@ private:
 
     // Set for both projection types
     float m_nearZ = 10;
-    float m_farZ = 200000;
+    float m_farZ = 48000;
     bool m_use_reverse_z = true;
 
     XMFLOAT3 m_position;

--- a/SourceFiles/MapRenderer.h
+++ b/SourceFiles/MapRenderer.h
@@ -26,6 +26,11 @@ using namespace DirectX;
 class MapRenderer
 {
 public:
+    // Reconstructed from Gw.exe gameplay camera path (GmView_UpdateCameraFrustum + Frame_SetCameraFovAndZFar).
+    static constexpr float kGwDefaultCameraFovDegrees = 50.0f;
+    static constexpr float kGwDefaultCameraNearZ = 10.0f;
+    static constexpr float kGwDefaultCameraFarZ = 48000.0f;
+
     MapRenderer(ID3D11Device* device, ID3D11DeviceContext* deviceContext, InputManager* input_manager)
         : m_device(device)
         , m_deviceContext(deviceContext)
@@ -42,10 +47,14 @@ public:
     void Initialize(const float viewport_width, const float viewport_height)
     {
         // Initialize cameras
-        float fov_degrees = 60.0f;
+        float fov_degrees = kGwDefaultCameraFovDegrees;
         float aspect_ratio = viewport_width / viewport_height;
-        m_user_camera->SetFrustumAsPerspective(static_cast<float>(fov_degrees * XM_PI / 180.0), aspect_ratio,
-            10.0f, 200000);
+        m_user_camera->SetFrustumAsPerspective(
+            static_cast<float>(fov_degrees * XM_PI / 180.0f),
+            aspect_ratio,
+            kGwDefaultCameraNearZ,
+            kGwDefaultCameraFarZ,
+            true);
         const auto pos = FXMVECTOR{ 0, 8500, 0, 0 };
         const auto target = FXMVECTOR{ 1000, 6000, 1000, 0 };
         const auto world_up = FXMVECTOR{ 0, 1, 0, 0 };
@@ -235,6 +244,16 @@ public:
                                  bool reverse_z = true)
     {
         m_user_camera->SetFrustumAsPerspective(fovY, aspectRatio, zNear, zFar, reverse_z);
+    }
+
+    void SetPerspectiveToGwGameplayDefaults()
+    {
+        m_user_camera->SetFrustumAsPerspective(
+            static_cast<float>(kGwDefaultCameraFovDegrees * XM_PI / 180.0f),
+            m_user_camera->GetAspectRatio(),
+            kGwDefaultCameraNearZ,
+            kGwDefaultCameraFarZ,
+            true);
     }
     void SetFrustumAsOrthographic(float view_width, float view_height, float near_z, float far_z,
                                   bool reverse_z = true)

--- a/SourceFiles/draw_right_panel.cpp
+++ b/SourceFiles/draw_right_panel.cpp
@@ -260,6 +260,22 @@ void draw_right_panel(MapRenderer* map_renderer, int& FPS_target, DX::StepTimer&
         float frustum_width = camera->GetViewWidth();
         float frustum_height = camera->GetViewHeight();
 
+        ImGui::TextDisabled("GW gameplay camera: perspective mode 2");
+        ImGui::TextDisabled("Default FoV %.1f, zFar %.0f",
+            MapRenderer::kGwDefaultCameraFovDegrees,
+            MapRenderer::kGwDefaultCameraFarZ);
+        if (ImGui::Button("Reset Projection To GW Defaults", ImVec2(-FLT_MIN, 0.0f)))
+        {
+            map_renderer->SetPerspectiveToGwGameplayDefaults();
+            camera_type = camera->GetCameraType();
+            fovY = camera->GetFovY() * 180 / XM_PI;
+            aspect_ratio = camera->GetAspectRatio();
+            near_z = camera->GetNearZ();
+            far_z = camera->GetFarZ();
+            frustum_width = camera->GetViewWidth();
+            frustum_height = camera->GetViewHeight();
+        }
+
         if (camera_type == CameraType::Perspective)
         {
             if (ImGui::SliderFloat("Vertical FoV", &fovY, 1, 179))

--- a/docs/gw_exact_camera_reverse_engineering.md
+++ b/docs/gw_exact_camera_reverse_engineering.md
@@ -1,0 +1,79 @@
+# Gw.exe Camera Reconstruction Notes
+
+## Scope
+- Binary: `Gw.exe` (`x86`)
+- Goal: reconstruct runtime camera setup exactly enough for GWMB parity.
+- Focused on gameplay/world camera path (not minimap/UI camera).
+
+## Core Runtime Call Path
+1. `GmView_HandleUIMessage @ 0x004DCC90`
+2. `GmCam_SetCameraTransform @ 0x004F05B0`
+3. `GmCam_UpdateShakeAndTransition @ 0x004ED680`
+4. `GmView_UpdateCameraFrustum @ 0x004E76B0`
+5. `GmView_UpdateWorldRender @ 0x004E56A0`
+6. `Map_update_camera @ 0x006E0C20`
+7. `Gr_Trans_LookAt @ 0x0064CB10` and `Frame_SetCameraFovAndZFar @ 0x0060FB30`
+
+## Camera Globals (World Camera)
+- `0x00BC2C00`: camera position (vec3)
+- `0x00BC2C0C`: camera target (vec3)
+- `0x00BC2C64`: camera FOV (float, radians)
+- `0x00BC2D48`: global `GmCam` object root
+
+## Important Constants
+- `0x009102B4 = 48000.0f` (world camera zFar used by frustum update)
+- `0x00906E1C = -1.0f` (used in up/screen-space helpers; gameplay up-vector uses `z = -1`)
+
+## FOV Units
+- `GmCam_SetFieldOfView @ 0x004F1030` converts degrees -> radians:
+  - `radians = degrees * PI / 180`
+- `GmCam` runtime FOV field read by `GmCam_GetCameraTransform`:
+  - `this + 0xC0`
+
+## View Setup (Exact Behavior)
+- In world rendering (`GmView_UpdateWorldRender` and `GmView_UpdateCameraFrustum`), the up vector passed is:
+  - `up = (0, 0, -1)`
+- Forward direction:
+  - `forward = normalize(target - position)`
+- `Map_update_camera` writes normalized direction output (same forward basis used by render path).
+
+## Projection Setup (Gameplay Path)
+- `GmView_UpdateCameraFrustum` calls:
+  - `Frame_SetCameraFovAndZFar(frameId, fov, zFar=48000, perspectiveMode)`
+- Perspective mode:
+  - normal gameplay uses mode `2`
+  - cinematic/reset-map path can use mode `0`
+- In `Gr_Trans_SetPerspective` mode `2`, frustum extents are built as:
+  - `halfHeight = zFar * tan(fov * 0.5)`
+  - `halfWidth  = halfHeight * aspect`
+  - rect = `[-halfWidth, -halfHeight, +halfWidth, +halfHeight]`
+
+## GmCam Transform Source
+- `GmCam_GetCameraTransform @ 0x004F21C0`:
+  - position source:
+    - `this + 0x78` (default), or `this + 0x90` depending on state (`this + 0x10C`)
+  - target source:
+    - `this + 0xA8`
+  - fov source:
+    - `this + 0xC0`
+  - optional shake offsets:
+    - `this + 0x110` block (`0x118..0x14C`)
+  - previous-valid fallback cache:
+    - `this + 0xF0..0x104` if degenerate transform
+
+## Reconstruction Recipe for GWMB
+1. Drive camera from `(position, target, fovRadians)` outputs, not from yaw/pitch integration.
+2. Use look-at basis from `position/target` each frame.
+3. Use world up equivalent to GW path.
+4. Use gameplay projection mode equivalent to GW mode `2` (with `zFar=48000`), unless emulating cinematic mode.
+5. Keep FOV in radians internally.
+
+## Coordinate Conversion Note
+- Existing GWMB comments for animation/mesh indicate GW->GWMB conversion:
+  - `(x, y, z)_GW -> (x, -z, y)_GWMB`
+- Under this mapping, GW up `(0,0,-1)` maps to GWMB up `(0,1,0)`.
+- If feeding camera values directly from live Gw.exe, convert position/target with the same basis transform before applying in GWMB.
+
+## Remaining Unknowns
+- Full semantic meaning of non-gameplay perspective mode conversions (`mode 0/1` conversion path via `GrTrans_CalcPerspectiveByType`).
+- Some `GmCam_UpdateCameraState` internals are mode/controller-specific and heavily intertwined with collision/avoidance and controller objects.


### PR DESCRIPTION
## Summary
- add reverse-engineering notes for Gw.exe camera setup
- set GW gameplay camera startup defaults (FoV 50, near 10, far 48000)
- keep camera projection editable at runtime and add reset-to-GW-defaults button in right panel

## Validation
- Debug|x64 build succeeds with MSBuild